### PR TITLE
separated passwordField and added read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@
 ENC_KEY = secret key
 DB_URL = mongoDB url
 ```
+
+# Material UI
+
+In previous course, teacher introduced Material UI a little bit to us. And we thought it would be good for using it to this project.
+
+Having a unified design would be neat since it is a same website that we worked on. It was important that visitor would feel that all pages are connected by design.
+
+So we discussed and decided to use some components with Material UI. For example, we use custom button(used MUI) that can be used again easily for everyone with our own theme colors.
+
+Material UI prevent us from spending lots of time for css and its animation. And it supports icons as well, so didn't need to spend so much time to use icons.

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,18 +1,12 @@
-import {
-  FormGroup,
-  TextField,
-  IconButton,
-  InputAdornment,
-  Grow,
-} from "@mui/material";
+import { FormGroup, TextField, Grow } from "@mui/material";
 import { Box } from "@mui/system";
 import React, { FormEvent, useState, useContext } from "react";
 import { CenterHorizon, CustomText, CustomButton } from "../CustomMUI/CustomUI";
-import { Visibility, VisibilityOff } from "@mui/icons-material";
-import { LoginProps, visiblePasswordState } from "../../types";
+import { LoginProps } from "../../types";
 import LoggedInModal from "./LoggedInModal";
 import useLoginStyles from "../CustomMUI/loginStyle";
 import { LoggedInContext } from "./IsLoggedIn";
+import PasswordField from "./PasswordField";
 
 const LoginForm: React.FC<LoginProps> = ({ newMember }) => {
   const [passwordWrong, setPasswordWrong] = useState<boolean>(false);
@@ -20,9 +14,7 @@ const LoginForm: React.FC<LoginProps> = ({ newMember }) => {
   const [userName, setUserName] = useState<string>("");
   const [userPassword, setUserPassword] = useState<string>("");
   const { changeLogInState } = useContext(LoggedInContext);
-  const [values, setValues] = useState<visiblePasswordState>({
-    showPassword: false,
-  });
+
   const { classes } = useLoginStyles();
 
   const handleSubmit = async (e: FormEvent) => {
@@ -44,18 +36,6 @@ const LoginForm: React.FC<LoginProps> = ({ newMember }) => {
     }
   };
 
-  const handleClickShowPassword = () => {
-    setValues({
-      showPassword: !values.showPassword,
-    });
-  };
-
-  const handleMouseDownPassword = (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => {
-    event.preventDefault();
-  };
-
   return (
     <>
       <Box className={classes.emptySpace}>
@@ -63,49 +43,27 @@ const LoginForm: React.FC<LoginProps> = ({ newMember }) => {
           <CustomText className={classes.loginTitle}>
             Välkommen till Risbäck
           </CustomText>
-          <CenterHorizon component='form'>
-            <FormGroup aria-label='position'>
+          <CenterHorizon component="form">
+            <FormGroup aria-label="position">
               <TextField
-                id='Username'
-                variant='outlined'
-                label='Användarnamn'
+                id="Username"
+                variant="outlined"
+                label="Användarnamn"
                 className={classes.userInput}
                 onChange={(e) => {
                   setUserName(e.target.value);
                   setPasswordWrong(false);
                 }}
                 required
-                color='info'
+                color="info"
               />
-              <TextField
-                id='UserPassword'
-                variant='outlined'
-                label='Lösenord'
-                type={values.showPassword ? "text" : "password"}
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position='end'>
-                      <IconButton
-                        aria-label='toggle password visibility'
-                        onClick={handleClickShowPassword}
-                        onMouseDown={handleMouseDownPassword}
-                        edge='end'
-                      >
-                        {values.showPassword ? (
-                          <VisibilityOff />
-                        ) : (
-                          <Visibility />
-                        )}
-                      </IconButton>
-                    </InputAdornment>
-                  ),
+              <PasswordField
+                setUserPassword={(value) => {
+                  setUserPassword(value);
                 }}
-                className={classes.userInput}
-                onChange={(e) => {
-                  setUserPassword(e.target.value);
-                  setPasswordWrong(false);
+                setPasswordWrong={(value) => {
+                  setPasswordWrong(value);
                 }}
-                required
               />
               <Box className={classes.emptyWarning}>
                 {passwordWrong ? (
@@ -126,9 +84,9 @@ const LoginForm: React.FC<LoginProps> = ({ newMember }) => {
               </Box>
               <CustomButton
                 onClick={handleSubmit}
-                color='secondary'
-                variant='contained'
-                type='submit'
+                color="secondary"
+                variant="contained"
+                type="submit"
                 className={classes.loginBtn}
               >
                 Logga in

--- a/src/components/login/PasswordField.tsx
+++ b/src/components/login/PasswordField.tsx
@@ -1,0 +1,82 @@
+import { Visibility, VisibilityOff } from "@mui/icons-material";
+import { IconButton, InputAdornment, TextField } from "@mui/material";
+import React, { useState } from "react";
+import { validatePassword } from "../../server/utils/password";
+import { visiblePasswordState } from "../../types";
+import useLoginStyles from "../CustomMUI/loginStyle";
+
+type passwordFieldType = {
+  setUserPassword: (value: string) => void;
+  setStrongPassword?: (value: boolean) => void | undefined;
+  setPasswordWrong?: (value: boolean) => void | undefined;
+};
+
+const PasswordField: React.FC<passwordFieldType> = ({
+  setUserPassword,
+  setStrongPassword,
+  setPasswordWrong,
+}) => {
+  const [values, setValues] = useState<visiblePasswordState>({
+    showPassword: false,
+  });
+
+  const handleStrongPassword = (value: string) => {
+    if (setStrongPassword) {
+      if (!validatePassword(value)) {
+        setStrongPassword(false);
+      } else {
+        setStrongPassword(true);
+      }
+    }
+  };
+
+  const handleClickShowPassword = () => {
+    setValues({
+      showPassword: !values.showPassword,
+    });
+  };
+
+  const handleMouseDownPassword = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault();
+  };
+
+  const { classes } = useLoginStyles();
+
+  return (
+    <>
+      <TextField
+        id="userPassword"
+        label="Lösenord"
+        variant="outlined"
+        type={values.showPassword ? "text" : "password"}
+        className={classes.userInput}
+        required
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={handleClickShowPassword}
+                onMouseDown={handleMouseDownPassword}
+                edge="end"
+              >
+                {values.showPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+        onChange={(e) => {
+          setUserPassword(e.target.value);
+
+          if (setStrongPassword) handleStrongPassword(e.target.value);
+
+          if (setPasswordWrong) setPasswordWrong(false);
+        }}
+      />
+    </>
+  );
+};
+
+export default PasswordField;

--- a/src/components/login/SignUp.tsx
+++ b/src/components/login/SignUp.tsx
@@ -1,10 +1,4 @@
-import {
-  FormGroup,
-  Grow,
-  IconButton,
-  InputAdornment,
-  TextField,
-} from "@mui/material";
+import { FormGroup, Grow, InputAdornment, TextField } from "@mui/material";
 import { Box } from "@mui/system";
 import React, { FormEvent, useState } from "react";
 
@@ -14,11 +8,9 @@ import {
   CustomText,
   PreviousPageBtn,
 } from "../CustomMUI/CustomUI";
-import { Visibility, VisibilityOff } from "@mui/icons-material";
-import { visiblePasswordState } from "../../types";
-import { validatePassword } from "../../server/utils/password";
 import DoNotDisturbAltIcon from "@mui/icons-material/DoNotDisturbAlt";
 import useLoginStyles from "../CustomMUI/loginStyle";
+import PasswordField from "./PasswordField";
 
 type signUpProp = {
   goBack: (value: boolean) => void;
@@ -31,10 +23,9 @@ const SignUp: React.FC<signUpProp> = ({ goBack }) => {
   const [userPassword, setUserPassword] = useState<string>("");
   const [firstName, setFirstName] = useState<string>("");
   const [lastName, setLastName] = useState<string>("");
-  const [values, setValues] = useState<visiblePasswordState>({
-    showPassword: false,
-  });
+
   const { classes } = useLoginStyles();
+
   const handleSignUp = async (e: FormEvent) => {
     e.preventDefault();
     if (strongPassword) {
@@ -57,25 +48,11 @@ const SignUp: React.FC<signUpProp> = ({ goBack }) => {
       }
     }
   };
-  const handleStrongPassword = (value: string) => {
-    if (!validatePassword(value)) {
-      setStrongPassword(false);
-    } else {
-      setStrongPassword(true);
-    }
-  };
 
-  const handleClickShowPassword = () => {
-    setValues({
-      showPassword: !values.showPassword,
-    });
-  };
-
-  const handleMouseDownPassword = (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => {
-    event.preventDefault();
-  };
+  const userInputField = [
+    { id: "firstName", label: "Förnamn", onChange: setFirstName },
+    { id: "lastName", label: "Efternamn", onChange: setLastName },
+  ];
 
   return (
     <>
@@ -107,40 +84,17 @@ const SignUp: React.FC<signUpProp> = ({ goBack }) => {
                   ),
                 }}
               />
-              <TextField
-                id="userPassword"
-                label="Lösenord"
-                variant="outlined"
-                type={values.showPassword ? "text" : "password"}
-                className={classes.userInput}
-                required
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      <IconButton
-                        aria-label="toggle password visibility"
-                        onClick={handleClickShowPassword}
-                        onMouseDown={handleMouseDownPassword}
-                        edge="end"
-                      >
-                        {values.showPassword ? (
-                          <VisibilityOff />
-                        ) : (
-                          <Visibility />
-                        )}
-                      </IconButton>
-                    </InputAdornment>
-                  ),
+
+              <PasswordField
+                setUserPassword={(value: string) => {
+                  setUserPassword(value);
                 }}
-                onChange={(e) => {
-                  setUserPassword(e.target.value);
-                  handleStrongPassword(e.target.value);
+                setStrongPassword={(value: boolean) => {
+                  setStrongPassword(value);
                 }}
               />
               <Box className={classes.emptyWarning}>
-                {strongPassword ? (
-                  ""
-                ) : (
+                {!strongPassword && (
                   <Grow
                     in={true}
                     style={{ transformOrigin: "0 0 0" }}
@@ -148,6 +102,7 @@ const SignUp: React.FC<signUpProp> = ({ goBack }) => {
                   >
                     <CustomText
                       className={strongPassword ? "" : classes.warning}
+                      sx={{ fontSize: "14px" }}
                     >
                       Lösenord : mer än 8 bokstavär + nummer + stor bokstav
                     </CustomText>
@@ -157,25 +112,20 @@ const SignUp: React.FC<signUpProp> = ({ goBack }) => {
               <CustomText sx={{ margin: "10px 0 0 5px" }}>
                 🔹Ditt namn
               </CustomText>
-              <TextField
-                id="firstName"
-                variant="outlined"
-                label="Förnamn"
-                type="name"
-                className={classes.userInput}
-                required
-                onChange={(e) => setFirstName(e.target.value)}
-                color="info"
-              />
-              <TextField
-                id="UserPassword"
-                label="Efternamn"
-                variant="outlined"
-                type="name"
-                className={classes.userInput}
-                required
-                onChange={(e) => setLastName(e.target.value)}
-              />
+
+              {userInputField.map((item) => (
+                <TextField
+                  key={item.id}
+                  id={item.id}
+                  label={item.label}
+                  variant="outlined"
+                  type="name"
+                  className={classes.userInput}
+                  required
+                  onChange={(e) => item.onChange(e.target.value)}
+                  color="info"
+                />
+              ))}
               <CustomButton
                 color="primary"
                 variant="contained"


### PR DESCRIPTION
I found that I write quite same codes several times with material UI (for example, user input with user name and password)
So I made password input field  as a component that I could use it again without writing same code. Plus added little read me.